### PR TITLE
docs: add Cursor Cloud development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,46 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Product overview
+
+Single **Nuxt 4** portfolio site (Vue 3, Nitro API routes, Pinia, `@nuxt/content`, `@nuxt/ui`). One dev process serves UI and `/api/*`. No Docker, no separate database server — `@nuxt/content` uses embedded SQLite via `better-sqlite3`.
+
+### Prerequisites
+
+- **Node.js 22** (see `.nvmrc`: `v22.20.0`)
+- **Bun** (lockfile is `bun.lock`; install from https://bun.sh if missing). Ensure `~/.bun/bin` is on `PATH`.
+
+### Commands
+
+| Task | Command |
+|------|---------|
+| Install deps | `bun install` (runs `nuxt prepare` via `postinstall`) |
+| Dev server | `bun run dev` → http://localhost:3000 |
+| Production build | `bun run build` |
+| Preview build | `bun run preview` |
+| Static generate | `bun run generate` |
+| Lint | `bun run lint` |
+| Format | `bun run format` |
+
+There is **no test script** in `package.json` despite `@nuxt/test-utils` being listed.
+
+### Services
+
+Only **one required service**: the Nuxt dev server (`bun run dev`). Use **tmux** for long-running dev (e.g. session name `nuxt-dev`).
+
+**Outbound HTTPS** to `css-tricks.com` is required for `/blogs` and `/api/blogs` (Cheerio scraper). No `.env` or secrets are used.
+
+### Gotchas
+
+- **Lint** may fail on pre-existing issues (e.g. `vue/no-multiple-template-root` in `app/layouts/default.vue`, `@typescript-eslint/no-explicit-any` in blog API routes). Build still succeeds.
+- **`@nuxt/image` / sharp**: build can warn that sharp linux-x64 binaries are missing; dev and build still complete.
+- **Hot reload**: after dependency changes, restart `bun run dev` if behavior looks stale.
+- Root `README.md` is a GitHub profile README, not app setup docs.
+
+### Hello-world smoke test
+
+1. `bun run dev`
+2. Open http://localhost:3000 — home hero loads
+3. Visit **Blogs** — posts from `/api/blogs`
+4. Submit **Contact** form — expect browser `alert()` confirmation (no backend email)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cursor Cloud-specific setup notes for this Nuxt 4 portfolio repo.

## What's included

- Prerequisites (Node 22, Bun)
- Standard commands (dev, build, lint)
- Service/runtime notes (single Nuxt process, css-tricks.com dependency for blogs)
- Known gotchas (pre-existing lint failures, sharp warning)
- Hello-world smoke test steps

## Demo

Verified in Cloud Agent VM:
- `bun install` + `bun run dev` on http://localhost:3000
- `bun run build` succeeds
- End-to-end browser test: home, blogs, projects, contact form submission

[portfolio-dev-demo.mp4](https://cursor.com/agents/bc-af9ac3f1-2ec0-43f3-a274-e179927245a0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fportfolio-dev-demo.mp4)

[Home page](https://cursor.com/agents/bc-af9ac3f1-2ec0-43f3-a274-e179927245a0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fhome-page.webp)
[Blogs page](https://cursor.com/agents/bc-af9ac3f1-2ec0-43f3-a274-e179927245a0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fblogs-page.webp)
[Contact form](https://cursor.com/agents/bc-af9ac3f1-2ec0-43f3-a274-e179927245a0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fcontact-form.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-af9ac3f1-2ec0-43f3-a274-e179927245a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-af9ac3f1-2ec0-43f3-a274-e179927245a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

