### PR TITLE
Fix Netlify 500 SSR error (Pinia + Nitro preset)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,5 +3,8 @@
   command = "pnpm run build"
   publish = "dist"
 
+[build.environment]
+  NODE_VERSION = "22"
+
 [functions]
   directory = ".netlify/functions-internal"

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,7 +1,22 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const rootDir = dirname(fileURLToPath(import.meta.url))
+const piniaEsm = join(rootDir, 'node_modules/pinia/dist/pinia.mjs')
+
 export default defineNuxtConfig({
   compatibilityDate: '2025-07-15',
   devtools: { enabled: true },
+  // Netlify SSR: use Nitro's Netlify preset (dist + serverless functions).
+  nitro: {
+    preset: 'netlify',
+  },
+  // Pinia's production Node export is CJS (pinia.prod.cjs) and imports Vue's
+  // default export, which breaks Nitro SSR. Force the ESM build instead.
+  alias: {
+    pinia: piniaEsm,
+  },
   modules: [
     '@nuxt/ui',
     '@pinia/nuxt',

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@nuxt/image": "^2.0.0",
     "@nuxt/ui": "^4.8.1",
     "@pinia/nuxt": "^0.11.3",
+    "pinia": "^3.0.4",
     "cheerio": "^1.2.0",
     "gsap": "^3.15.0",
     "lodash-es": "^4.18.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       nuxt:
         specifier: ^4.4.6
         version: 4.4.6(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(db0@0.3.4)(ioredis@5.11.0)(lightningcss@1.32.0)(magicast@0.5.3)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.4))(rollup@4.60.4)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0))(yaml@2.9.0)
+      pinia:
+        specifier: ^3.0.4
+        version: 3.0.4(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3))
       tailwindcss:
         specifier: ^4.3.0
         version: 4.3.0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

https://amirmaghami.ir/ returned **500 / undefined** on Netlify. The Nitro SSR handler crashed on every page request with:

```
SyntaxError: The requested module 'vue' does not provide an export named 'default'
```

## Root cause

In **production** Node resolution, Pinia's `package.json` exports point to `pinia.prod.cjs`, which expects Vue's **default** export. Vue 3 ESM does not provide that, so the serverless function failed during SSR.

## Fix

1. **Alias Pinia to its ESM build** (`pinia/dist/pinia.mjs`) so production SSR uses named Vue imports.
2. **Add `pinia` as a direct dependency** (recommended with `@pinia/nuxt`).
3. **Set `nitro.preset: 'netlify'`** so the build outputs `dist/` + `.netlify/functions-internal/` as expected by `netlify.toml`.
4. **Pin Node 22** in Netlify build environment.

## Verification

After `pnpm build`, invoking the Netlify server handler locally:

```js
const res = await handler(new Request('https://amirmaghami.ir/'))
// status 200, HTML includes "Amir Maghami"
```

## Deploy

Merge and trigger a Netlify deploy (or redeploy from the Netlify dashboard).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-34a58d7a-10c6-427a-bede-35a0729a1d8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-34a58d7a-10c6-427a-bede-35a0729a1d8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

